### PR TITLE
Fix targeting key in localStorage for removal

### DIFF
--- a/src/Helper/hooks/useLocalStorage.js
+++ b/src/Helper/hooks/useLocalStorage.js
@@ -30,7 +30,7 @@ export const useLocalStorage = (
     const prevKey = keyRef.current;
 
     if (prevKey !== key) {
-      localStorage.removeItem(key);
+      localStorage.removeItem(prevKey);
     }
 
     keyRef.current = key;


### PR DESCRIPTION
I have just realised that there was a small issue with the cleanup in the localStorage hook. 🤦‍♀️ 